### PR TITLE
fix: improve styles into check page

### DIFF
--- a/src/components/Form/Form.styled.jsx
+++ b/src/components/Form/Form.styled.jsx
@@ -11,7 +11,7 @@ export const FormContainer = styled.form`
 export const FormButton = styled.button`
   width: 280px;
   height: 40px;
-  border-radius: 20px;
+  border-radius: 2rem;
   margin: 10px;
   margin-top: 60px;
   border: none;
@@ -25,5 +25,9 @@ export const FormButton = styled.button`
   &:focus {
     border: solid 1px var(--dark, #000);
     box-shadow: 2px 5px 6px rgb(0 0 0 / 0.3);
+  }
+
+  @media (min-width: 960px) {
+    width: 350px;
   }
 `

--- a/src/components/FormInput.jsx
+++ b/src/components/FormInput.jsx
@@ -2,8 +2,9 @@ import styled from 'styled-components'
 
 export const FormInput = styled.input`
   width: 280px;
-  height: 45px;
-  border-radius: 20px;
+  height: 40px;
+
+  border-radius: 2rem;
 
   padding-left: 20px;
   margin: 10px;
@@ -14,15 +15,24 @@ export const FormInput = styled.input`
   display: block;
 
   ::placeholder {
-    font-size: 0.8rem;
     font-weight: bold;
-    color: var(--light-gray-2);
+    color: #acb3ba;
+    font-size: 0.8rem;
   }
 
   &:focus {
     border: solid 1px var(--dark, #000);
     box-shadow: 2px 5px 6px rgb(0 0 0 / 0.3);
     outline: none;
+  }
+
+  @media (min-width: 960px) {
+    width: 350px;
+    height: 60px;
+
+    ::placeholder {
+      font-size: 1rem;
+    }
   }
 `
 

--- a/src/pages/Check/Check.jsx
+++ b/src/pages/Check/Check.jsx
@@ -5,6 +5,7 @@ import warning from '../../assets/warning.png'
 import { useGetPackagesIdByCode } from '../../hooks'
 import Layout from './Check.layout'
 import FormInput from '../../components/FormInput'
+import { TextHandlerColorMobile } from './Check.styled'
 
 const Check = () => {
   const [packageCode, setPackageCode] = useState('')
@@ -46,9 +47,9 @@ const Check = () => {
       }
     >
       <div className="check-ticket">
-        <Text color="secondary" bold uppercase>
+        <TextHandlerColorMobile color="secondary" bold uppercase>
           Confirmar n° boleta o pedido
-        </Text>
+        </TextHandlerColorMobile>
         <Form formData={setPackageCode} onSubmit={e => toDelivery(e)}>
           {({ handleFormChange, value }) => (
             <>

--- a/src/pages/Check/Check.layout.jsx
+++ b/src/pages/Check/Check.layout.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 
 import { Container, Header, TicketImage, MainSection } from '../../layouts/Splitted.styled'
-import { CheckText, CheckTextSubtitle } from './Check.components'
+import { CheckText, CheckTextSubtitle } from './Check.styled'
 import ticket from '../../assets/ticket.png'
 
 import BackButton from '../../components/BackButton'

--- a/src/pages/Check/Check.styled.jsx
+++ b/src/pages/Check/Check.styled.jsx
@@ -5,8 +5,9 @@ export const CheckText = styled(Text)`
   margin: 0;
 
   @media (min-width: 960px) {
-    font-size: 3.5rem;
+    font-size: 6rem;
     margin-top: 10rem;
+    margin-bottom: 1.2rem;
   }
 `
 
@@ -17,5 +18,12 @@ export const CheckTextSubtitle = styled(Text)`
   @media (min-width: 960px) {
     font-size: 2rem;
     margin-top: 2rem;
+  }
+`
+export const TextHandlerColorMobile = styled(Text)`
+  @media (min-width: 960px) {
+    color: var(--primary);
+    font-weight: bold;
+    font-size: 1.3rem;
   }
 `

--- a/src/styles/theme.js
+++ b/src/styles/theme.js
@@ -13,6 +13,7 @@ const GlobalStyles = createGlobalStyle`
   --light-gray-2: ${({ theme }) => theme.colors.gray04};
   --white: white;
   --danger: ${({ theme }) => theme.colors.gray09};
+  --blue-text: ${({ theme }) => theme.colors.blue06};
 
   --font-family: 'Poppins', sans-serif;
   --z-normal: 0;


### PR DESCRIPTION
### Description

- The web input label was painted blue and kept yellow for mobile.

- Adjusted the size of the html elements in web and kept it in mobile

- Changed styles file from .components to .styled to respect convention

- #135 

#### Screenshots
![image](https://user-images.githubusercontent.com/29690711/141172387-743ff27a-6710-49ed-8117-841f21952508.png)

#### Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
