### PR TITLE
Fixed ErrorBoundary

### DIFF
--- a/src/layouts/ErrorBoundary.js
+++ b/src/layouts/ErrorBoundary.js
@@ -1,6 +1,5 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
-// import { logError } from '../helpers'
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -9,7 +8,6 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    // logError({ error, codeLocation: 'codeLocation', type: 'crash' }) // the logError crash the app in production environment
     this.setState({
       error: error,
       errorInfo: errorInfo,

--- a/src/layouts/ErrorBoundary.js
+++ b/src/layouts/ErrorBoundary.js
@@ -1,6 +1,5 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
-import Error from '../pages/Error'
 import { logError } from '../helpers'
 
 export default class ErrorBoundary extends Component {
@@ -10,6 +9,7 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
+    logError({ error, codeLocation: 'codeLocation', type: 'crash' })
     this.setState({
       error: error,
       errorInfo: errorInfo,
@@ -17,11 +17,27 @@ export default class ErrorBoundary extends Component {
   }
 
   render() {
-    const { errorInfo, error } = this.state
-
-    if (errorInfo) {
-      const errorId = logError({ error, codeLocation: 'codeLocation', type: 'crash' })
-      return <Error errorInfo={errorInfo} errorId={errorId} />
+    if (this.state.errorInfo) {
+      return (
+        <div>
+          <p>
+            There was an error in loading this page.{' '}
+            <button
+              style={{ cursor: 'pointer', color: '#0077FF' }}
+              onClick={() => {
+                window.location.reload()
+              }}
+            >
+              Reload this page
+            </button>{' '}
+          </p>
+          <details style={{ whiteSpace: 'pre-wrap' }}>
+            {this.state.error && this.state.error.toString()}
+            <br />
+            {this.state.errorInfo.componentStack}
+          </details>
+        </div>
+      )
     }
     return this.props.children
   }

--- a/src/layouts/ErrorBoundary.js
+++ b/src/layouts/ErrorBoundary.js
@@ -1,6 +1,6 @@
 import { Component } from 'react'
 import PropTypes from 'prop-types'
-import { logError } from '../helpers'
+// import { logError } from '../helpers'
 
 export default class ErrorBoundary extends Component {
   constructor(props) {
@@ -9,7 +9,7 @@ export default class ErrorBoundary extends Component {
   }
 
   componentDidCatch(error, errorInfo) {
-    logError({ error, codeLocation: 'codeLocation', type: 'crash' })
+    // logError({ error, codeLocation: 'codeLocation', type: 'crash' }) // the logError crash the app in production environment
     this.setState({
       error: error,
       errorInfo: errorInfo,

--- a/src/layouts/ErrorBoundary.js
+++ b/src/layouts/ErrorBoundary.js
@@ -6,32 +6,23 @@ import { logError } from '../helpers'
 export default class ErrorBoundary extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      error: '',
-      errorInfo: '',
-      hasError: false,
-    }
-  }
-
-  static getDerivedStateFromError(_error) {
-    if (_error) {
-      return { hasError: true }
-    }
+    this.state = { error: null, errorInfo: null }
   }
 
   componentDidCatch(error, errorInfo) {
-    this.setState({ errorInfo, error })
+    this.setState({
+      error: error,
+      errorInfo: errorInfo,
+    })
   }
 
   render() {
-    const { hasError, errorInfo, error } = this.state
+    const { errorInfo, error } = this.state
 
-    if (hasError) {
-      const errorId = logError({ error: error, codeLocation: 'codeLocation', type: 'crash' })
-      // @ts-ignore
+    if (errorInfo) {
+      const errorId = logError({ error, codeLocation: 'codeLocation', type: 'crash' })
       return <Error errorInfo={errorInfo} errorId={errorId} />
     }
-
     return this.props.children
   }
 }


### PR DESCRIPTION
### Description

The initial problem with the Error Boundary was that, it didn't catch the errors.
In the React documentation, they explain the errors that this component can't catch

Currently the `ErrorBoundary` can catch errors like `throw new Error("error message")`, `[].toUpperCase()`, `undefined.data`. However, the errors of compilation, errors of asyncronous code or Javascript syntax errors, can't be catched for this.

fixes #104 

#### Screenshots
![image](https://user-images.githubusercontent.com/61360270/150533010-d184da1d-f1c1-44ff-8a87-134a245b0020.png)
