### PR TITLE
fix: desktop screen size now start on 1025px instead of 960px

### DIFF
--- a/src/components/Form/Form.styled.jsx
+++ b/src/components/Form/Form.styled.jsx
@@ -27,7 +27,7 @@ export const FormButton = styled.button`
     box-shadow: 2px 5px 6px rgb(0 0 0 / 0.3);
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 350px;
   }
 `

--- a/src/components/FormInput.jsx
+++ b/src/components/FormInput.jsx
@@ -26,7 +26,7 @@ export const FormInput = styled.input`
     outline: none;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 350px;
     height: 60px;
 

--- a/src/components/Map/index.js
+++ b/src/components/Map/index.js
@@ -15,7 +15,7 @@ const Wrapper = styled.main`
   margin: 30px auto;
   justify-content: center;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 70vw;
   }
 

--- a/src/layouts/Splitted.styled.jsx
+++ b/src/layouts/Splitted.styled.jsx
@@ -7,7 +7,7 @@ export const Container = styled.div`
   width: 100vw;
   background: var(--white);
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     flex-direction: row;
   }
 `
@@ -23,7 +23,7 @@ export const Header = styled.div`
     flex: none;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 50%;
     padding-top: 3rem;
     border-radius: 0000;
@@ -41,7 +41,7 @@ export const TicketImage = styled.img`
   align-self: flex-start;
   margin: 2.5rem 0 -13px 15px;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 40vh;
     bottom: -38px;
     align-self: flex-end;
@@ -55,7 +55,7 @@ export const ConfirmImage = styled.img`
   align-self: flex-start;
   margin: 0 0 -13px 15px;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 40vh;
     bottom: -38px;
     align-self: flex-end;
@@ -71,7 +71,7 @@ export const MainSection = styled.div`
   align-content: center;
   text-align: center;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     background: var(--secondary);
     width: 50%;
     height: 100vh;

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -16,7 +16,7 @@ export const HeaderChat = styled.div`
   width: 100%;
   grid-row: 1/2;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     height: 12vh;
   }
 
@@ -47,7 +47,7 @@ export const HeaderText = styled.div`
   flex: 1;
   flex-direction: column;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     font-size: 2em;
   }
 
@@ -104,7 +104,7 @@ export const MessageRow = styled.div`
   grid-template-columns: 40px calc(100% - 40px - 2rem);
   width: 100%;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 47vw;
   }
 
@@ -141,7 +141,7 @@ export const Avatar = styled.img`
   max-width: 50px;
   margin: auto 0;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: 4vw;
   }
 `

--- a/src/pages/Check/Check.styled.jsx
+++ b/src/pages/Check/Check.styled.jsx
@@ -4,7 +4,7 @@ import { Text } from '../../components'
 export const CheckText = styled(Text)`
   margin: 0;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     font-size: 6rem;
     margin-top: max(2.5rem, 13vh);
     margin-bottom: 1.2rem;
@@ -18,13 +18,13 @@ export const CheckTextSubtitle = styled(Text)`
   margin: 0;
   font-weight: bold;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     font-size: 2rem;
     margin-top: 2rem;
   }
 `
 export const TextHandlerColorMobile = styled(Text)`
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     color: var(--primary);
     font-weight: bold;
     font-size: 1.3rem;

--- a/src/pages/Delivery/Delivery.styled.jsx
+++ b/src/pages/Delivery/Delivery.styled.jsx
@@ -58,7 +58,7 @@ const ChatBtn = styled.img`
   cursor: pointer;
   margin: auto 0;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     width: auto;
     height: 7vh;
   }
@@ -128,7 +128,7 @@ const FooterMapAddress = styled.div`
     font-size: 0.7em;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     font-size: 1em;
   }
 
@@ -146,7 +146,7 @@ const MapContainer = styled.div`
     min-height: 100vh;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     margin: 0 auto;
   }
 `

--- a/src/pages/Home/Home.styled.jsx
+++ b/src/pages/Home/Home.styled.jsx
@@ -91,7 +91,7 @@ export const DisplayText = styled(Text)`
     margin: 2rem 0 30px 30px;
   }
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     font-size: 6.5rem;
     text-align: left;
     margin: 10px 0 30px -5px;
@@ -102,7 +102,7 @@ export const SubtitleText = styled(Text)`
   margin-top: 3px;
   font-size: 1rem;
 
-  @media (min-width: 960px) {
+  @media (min-width: 1025px) {
     margin: 15px 0;
     font-size: 2rem;
     line-height: 30px;


### PR DESCRIPTION
### Description

I have moved all media queries to do that desktop sizes were screens > 1024px. This is because some tablets have so big screens and look bad that a table was a desktop view.

fixes #145 
fixes #149 

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/151582724-1e096420-294c-4a57-ac91-d3a318ae6c8a.png)
![imagen](https://user-images.githubusercontent.com/66505715/151582753-5aa86b3f-a12d-4e70-804e-ba34458a42a1.png)

#### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test it

1. Go to deploy link
2. Click on inspect element
3. Change the responsive size to 1024px

### Checklist:

- [x] All screens <= 1024px are considered a Tablet/Mobile View
- [x] All screens > 1024px are considered a Desktop View
- [x]  Chat view looks how mobile design in iPad Pro screen
- [x] Profile picture is not so big
- [x] Back button is not so big
