### PR TITLE
Added fixed height to header in chat view and fixed the way to center elements in the navbar

### DIFF
--- a/src/components/BackButton/BackButton.styled.jsx
+++ b/src/components/BackButton/BackButton.styled.jsx
@@ -4,30 +4,18 @@ export const BackBtnContainer = styled.div`
   display: flex;
   width: 33.33vw;
   max-height: 68px;
-
-  @media (max-width: 960px) {
-    padding-left: 15px;
-    margin-top: 1rem;
-  }
+  align-items: center;
+  margin-left: -10px;
 
   @media (min-width: 961px) {
-    margin-top: 0.5rem;
-    padding-left: 10px;
+    margin-left: -6px;
   }
 `
 export const BackBtn = styled.img`
   cursor: pointer;
-  position: relative;
-  left: -15px;
   margin: 0;
-  margin-bottom: 30px;
 
   @media (max-width: 960px) {
-    height: 100%;
-    padding-right: 15vw;
-  }
-
-  @media (min-width: 961px) {
     height: 100%;
   }
 `
@@ -39,12 +27,10 @@ export const BackTxt = styled.p`
   font-size: 1em;
   margin: auto 0;
   max-width: 10rem;
-
-  @media (max-width: 960px) {
-    display: none;
-  }
+  display: none;
 
   @media (min-width: 961px) {
+    display: block;
     font-size: 1.5em;
   }
 

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -37,10 +37,8 @@ export const HeaderChatImg = styled.img`
 `
 
 export const HeaderText = styled.div`
-  ${[m({ x: '0', y: 'auto' }), size({ width: '33.33%' }), text.base, text[700], text.secondary, text.textCenter]}
+  ${[size({ width: '33.33%' }), text.base, text[700], text.secondary, text.textCenter]}
   display: flex;
-  flex: 1;
-  flex-direction: column;
 
   @media (min-width: 1025px) {
     font-size: 2em;

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -12,18 +12,13 @@ export const HeaderChat = styled.div`
   ${[rounded({ bl: '25px', br: '25px' }), p({ all: '1.5%' }), size({ height: '11vh' }), bg.primary]}
   display: flex;
   flex-direction: row;
+  align-items: center;
   position: fixed;
   width: 100%;
   grid-row: 1/2;
-
-  @media (min-width: 1025px) {
-    height: 12vh;
-  }
-
-  @media (min-width: 3180px) {
-    height: 14vh;
-  }
+  height: 80px;
 `
+
 export const HeaderChatImgContainer = styled.div`
   width: 33.33vw;
   text-align: right;

--- a/src/pages/Delivery/Delivery.styled.jsx
+++ b/src/pages/Delivery/Delivery.styled.jsx
@@ -9,6 +9,7 @@ const MapLayoutContainer = styled.div`
 
 const HeaderMap = styled.div`
   display: flex;
+  align-items: center;
   flex-direction: row;
   background: var(--primary);
   border-bottom-right-radius: 25px;


### PR DESCRIPTION
### Description

I have added a fixed height to the header in the chat view. I have changed too the way to center elements at the navbar, since we are using flex, is better continue using flex to center vertically the elements

fixes #196

#### Screenshots
Before: (Please note how the arrow is so down)
![imagen](https://user-images.githubusercontent.com/66505715/151598899-48169cc5-27b4-4b8f-8fcc-6cedcf2ef970.png)

Now: (Please note how now all is more centered)
![imagen](https://user-images.githubusercontent.com/66505715/151598954-792e6d40-db2a-4fe8-9f72-bfa0b17104d7.png)

#### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test it

If applicable, describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

1. Go to deploy link
2. Please check all views that contain the back button to know if all is good. On another hand, please go to `/chat/1` to see the chat changes

### Checklist:

- [x] The header have min height and look goods
- [x] The back button and the avatar at small vertical screens looks good
- [x] Checked if max height is needed and added if is needed