### PR TITLE
Aligned the text at home

### DIFF
--- a/src/pages/Home/Home.styled.jsx
+++ b/src/pages/Home/Home.styled.jsx
@@ -83,18 +83,17 @@ export const Text = styled(OriginalText)`
 export const DisplayText = styled(Text)`
   font-size: 3rem;
   text-align: left;
-  margin: 3rem 0 5px -5px;
+  margin: 0px;
   text-align: left;
 
   @media (min-width: 768px) {
     font-size: 5rem;
     text-align: left;
-    margin: 2rem 0 30px 30px;
   }
 
   @media (min-width: 1025px) {
     font-size: 6.5rem;
-    margin: 10px 0 30px -5px;
+    line-height: 1;
   }
 `
 
@@ -104,15 +103,12 @@ export const SubtitleText = styled(Text)`
   text-align: left;
 
   @media (min-width: 1025px) {
-    margin: 15px 0;
     font-size: 2rem;
-    line-height: 30px;
+    line-height: 1;
   }
 
   @media (min-width: 768px) {
-    margin: 15px 0;
     font-size: 1.5rem;
-    line-height: 30px;
   }
 `
 export const Button = styled(Link)`

--- a/src/pages/Home/Home.styled.jsx
+++ b/src/pages/Home/Home.styled.jsx
@@ -84,6 +84,7 @@ export const DisplayText = styled(Text)`
   font-size: 3rem;
   text-align: left;
   margin: 3rem 0 5px -5px;
+  text-align: left;
 
   @media (min-width: 768px) {
     font-size: 5rem;
@@ -93,7 +94,6 @@ export const DisplayText = styled(Text)`
 
   @media (min-width: 1025px) {
     font-size: 6.5rem;
-    text-align: left;
     margin: 10px 0 30px -5px;
   }
 `
@@ -101,6 +101,7 @@ export const DisplayText = styled(Text)`
 export const SubtitleText = styled(Text)`
   margin-top: 3px;
   font-size: 1rem;
+  text-align: left;
 
   @media (min-width: 1025px) {
     margin: 15px 0;

--- a/src/pages/Home/Home.styled.jsx
+++ b/src/pages/Home/Home.styled.jsx
@@ -91,11 +91,11 @@ export const DisplayText = styled(Text)`
   @media (min-width: 768px) {
     font-size: 5rem;
     text-align: left;
+    line-height: 1;
   }
 
   @media (min-width: 1025px) {
     font-size: 6.5rem;
-    line-height: 1;
   }
 `
 

--- a/src/pages/Home/Home.styled.jsx
+++ b/src/pages/Home/Home.styled.jsx
@@ -70,8 +70,10 @@ export const ManImage = styled.img`
 `
 export const TextContainer = styled.div`
   max-width: 100%;
+  margin-top: 3rem;
 
   @media (min-width: 768px) {
+    margin-top: 0px;
     max-width: 70%;
   }
 `


### PR DESCRIPTION
### Description

I have to aligned the text at home view and improve the way to manage the spaces between text.

I have checked and the original design have all text aligned to the left and not center

fixes #148

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/151604229-39ea807a-29db-436a-b356-9dfa696fbe43.png)
![image](https://user-images.githubusercontent.com/66505715/151628376-bb354a19-f760-4056-a7eb-c6ccff6fd293.png)

#### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test it

1. Go to deploy link
2. Check the home in different screen sizes

### Checklist:

- [x] The text is aligned at iPad Pro screen
- [x] The text is aligned in other screen sizes
