### PR TITLE
Now subtitle is not way down

### DIFF
--- a/src/components/Modal/Modal.styled.jsx
+++ b/src/components/Modal/Modal.styled.jsx
@@ -42,6 +42,7 @@ export const InfoContainer = styled.div`
   h1 {
     font-size: 20px;
     color: blue;
+    margin-bottom: 0;
   }
 
   p {
@@ -49,6 +50,11 @@ export const InfoContainer = styled.div`
     color: gray;
     padding-left: 16px;
     padding-right: 16px;
+  }
+
+  h4{
+    margin-top: 0;
+    margin-bottom: 2rem;
   }
 
   ul {

--- a/src/pages/Delivery/index.jsx
+++ b/src/pages/Delivery/index.jsx
@@ -52,7 +52,7 @@ const Delivery = () => {
       toChat={toChat}
       DeliveryConfirmedModal={
         <Modal
-          isOpen={currentStatus === 'destination_reached' && openDeliveryConfirmedModal}
+          isOpen={true}
           handleClick={() => {
             toggleDeliveryConfirmedModal(!openDeliveryConfirmedModal)
             toConfirm()

--- a/src/pages/Delivery/index.jsx
+++ b/src/pages/Delivery/index.jsx
@@ -52,7 +52,7 @@ const Delivery = () => {
       toChat={toChat}
       DeliveryConfirmedModal={
         <Modal
-          isOpen={true}
+          isOpen={currentStatus === 'destination_reached' && openDeliveryConfirmedModal}
           handleClick={() => {
             toggleDeliveryConfirmedModal(!openDeliveryConfirmedModal)
             toConfirm()


### PR DESCRIPTION
### Description

ildbr has fixed the problem present at the issue #150

fixes #150 

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/152007495-eae1547d-fb06-4d1f-be5e-69d1a01c92ee.png)

#### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test it

Access to this view using the slug "/delivery/751f5ea3-f005-4dd9-b24e-5a779a208270". Example: https://dev--azordev-dasher-user.netlify.app/delivery/751f5ea3-f005-4dd9-b24e-5a779a208270

1. Change the condition on this file to do that the modal was opened always while you work on this. (check the line 57) 
https://github.com/Azordev/dasher-user/blob/f8817d63ab0fb428d6c6b7bd633ea0838df3fd41/src/pages/Delivery/index.jsx#L55-L63
2. Go to your local environment, example `localhost/delivery/751f5ea3-f005-4dd9-b24e-5a779a208270`

### Checklist:

- [x] The subtitle and the title aren't so separated between
