### PR TITLE
Fixed the chat containers size

### DIFF
--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import { bg, m, p, rounded, size, text } from '../../styles/mixins'
+import { bg, p, rounded, size, text } from '../../styles/mixins'
 
 export const ChatLayoutContainer = styled.div`
   ${[size({ width: '100vw', minHeight: '100vh' }), bg.white]}
@@ -105,11 +105,12 @@ export const FooterChatInput = styled.form`
 export const MessageRow = styled.div`
   margin: 10px 0;
   display: grid;
-  grid-template-columns: 40px calc(100% - 40px - 2rem);
+  grid-template-columns: 50px calc(100% - 50px - 2rem);
   width: 100%;
 
   @media (min-width: 1025px) {
     width: 47vw;
+    gap: 11px;
   }
 
   &::after {
@@ -141,13 +142,7 @@ export const MessageBox = styled.div`
 `
 
 export const Avatar = styled.img`
-  float: ${({ type }) => (type === 'client' ? `left` : `right`)};
   width: 4vw;
   min-width: 40px;
   max-width: 50px;
-  margin: auto 0;
-
-  @media (min-width: 1025px) {
-    width: 4vw;
-  }
 `

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -67,15 +67,26 @@ export const ChatBodyWrapper = styled.div`
 export const FooterChat = styled.div`
   width: 100%;
   grid-row: 3/-1;
+  display: flex;
+  align-items: center;
 `
 
 export const FooterChatInput = styled.form`
   ${[p({ x: '0', y: '5%' }), text.textCenter, bg.white]}
   flex: ${props => props.cols};
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  background-color: var(--secondary);
   padding: 0.5rem;
+
+  div {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin: 0px auto;
+
+    @media (min-width: 1025px) {
+      width: 47vw;
+    }
+  }
 
   button {
     margin: 1rem;
@@ -118,7 +129,7 @@ export const MessageBox = styled.div`
     bg.gray,
   ]}
   display: inline-block;
-  width: 100%;
+  width: max-content;
   overflow-wrap: break-word;
 
   @media (min-width: 3180px) {

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -130,6 +130,8 @@ export const MessageBox = styled.div`
   ]}
   display: inline-block;
   width: max-content;
+  min-width: 80px;
+  max-width: 100%;
   overflow-wrap: break-word;
 
   @media (min-width: 3180px) {

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -4,7 +4,7 @@ import { bg, p, rounded, size, text } from '../../styles/mixins'
 export const ChatLayoutContainer = styled.div`
   ${[size({ width: '100vw', minHeight: '100vh' }), bg.white]}
   display: grid;
-  grid-template-rows: 100px calc(100vh - 200px) 100px;
+  grid-template-rows: 80px calc(100vh - 185px) 105px;
   overflow: hidden;
 `
 

--- a/src/pages/Chat/Chat.styled.jsx
+++ b/src/pages/Chat/Chat.styled.jsx
@@ -57,11 +57,15 @@ export const HeaderTitle = styled.div`
 
 export const ChatBodyWrapper = styled.div`
   grid-row: 2/3;
-  padding: 1rem 2rem;
+  padding: 1rem 0.8rem;
   overflow-y: scroll;
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  @media (min-width: 1025px) {
+    padding: 1rem 2rem;
+  }
 `
 
 export const FooterChat = styled.div`
@@ -120,20 +124,17 @@ export const MessageRow = styled.div`
 `
 
 export const MessageBox = styled.div`
-  ${[
-    m({ x: '1vw', y: '0' }),
-    p({ all: '10px' }),
-    rounded({ all: '15px' }),
-    size({ width: '40vw' }),
-    text.base,
-    text.gray09,
-    bg.gray,
-  ]}
+  ${[p({ all: '10px' }), rounded({ all: '15px' }), size({ width: '40vw' }), text.base, text.gray09, bg.gray]}
   display: inline-block;
   width: max-content;
   min-width: 80px;
   max-width: 100%;
   overflow-wrap: break-word;
+  font-size: 0.9rem;
+
+  @media (min-width: 768px) {
+    font-size: 1rem;
+  }
 
   @media (min-width: 3180px) {
     line-height: 3.5vw;

--- a/src/pages/Chat/index.jsx
+++ b/src/pages/Chat/index.jsx
@@ -63,16 +63,18 @@ const Chat = () => {
           cols={'0 0 100%'}
           onSubmit={handleSubmit}
         >
-          <Input
-            // @ts-ignore
-            bgColor="gray"
-            placeholder="Escribe aqui..."
-            value={message}
-            onChange={e => setMessage(e.target.value)}
-          />
-          <button type="submit">
-            <img src={sendChat} alt="send Chat" />
-          </button>
+          <div>
+            <Input
+              // @ts-ignore
+              bgColor="gray"
+              placeholder="Escribe aqui..."
+              value={message}
+              onChange={e => setMessage(e.target.value)}
+            />
+            <button type="submit">
+              <img src={sendChat} alt="send Chat" />
+            </button>
+          </div>
         </FooterChatInput>
       }
     >


### PR DESCRIPTION
### Description

I have added the styles described at the issue to improve the visualization of chat view.

fixes #198

#### Screenshots

Now:
![imagen](https://user-images.githubusercontent.com/66505715/152030502-36cc13c4-8237-4538-98ec-4d57ce811d1f.png)

Before:
![imagen](https://user-images.githubusercontent.com/66505715/152030546-10ae9324-b5b4-4c8b-9e6f-dd0a1e8ffec4.png)

#### Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### How to test it

To access to this view try accessing to /chat/1 route

Example:
https://dev--azordev-dasher-user.netlify.app/chat/1

### Checklist:

- [x] Chat bubbles are not occupying 100% of width, only the space required for the message to show as in the screenshot. This will allow the user to read better and differenciate between their messages and delivery messages
- [x] The input container background should be yellow, this change was to be done at delivery app and should be applied here.
- [x] The input to send message should have the same width that the chat's body container
- [x] Try to look if other containers needs to be fixed on this view  