### PR TITLE
Set tab size for workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,8 @@
   },
   "editor.formatOnSave": true,
   "editor.bracketPairColorization.enabled": true,
+  "editor.insertSpaces": true,
+  "editor.tabSize": 2,
   "javascript.autoClosingTags": true,
   "javascript.suggest.autoImports": true,
   "javascript.format.enable": false,
@@ -57,5 +59,5 @@
     }
   ],
   "githubIssues.issueBranchTitle": "feature/#${issueNumber}",
-  "js/ts.implicitProjectConfig.checkJs": true
+  "js/ts.implicitProjectConfig.checkJs": true,
 }


### PR DESCRIPTION
### Description

I have set tab size for the Dasher User workspace

fixes #219

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/152230822-f8e845dc-13c8-4b24-a543-b27356e5dcc7.png)

#### Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)