### PR TITLE
Fixed styles on Confirm Modal

### DIFF
--- a/src/components/Modal/Modal.styled.jsx
+++ b/src/components/Modal/Modal.styled.jsx
@@ -47,12 +47,11 @@ export const InfoContainer = styled.div`
 
   p {
     font-size: 16px;
-    color: gray;
     padding-left: 16px;
     padding-right: 16px;
   }
 
-  h4{
+  h4 {
     margin-top: 0;
     margin-bottom: 2rem;
   }

--- a/src/pages/Confirm/Confirm.styled.jsx
+++ b/src/pages/Confirm/Confirm.styled.jsx
@@ -10,6 +10,8 @@ export const RatingImg = styled.img`
 export const ConfirmText = styled(Text)`
   margin: 0px;
   line-height: 1.5;
+  text-align: center;
+  font-size: 18px !important;
 
   &:nth-child(2) {
     margin: 0px 0px 15px;

--- a/src/pages/Confirm/Confirm.styled.jsx
+++ b/src/pages/Confirm/Confirm.styled.jsx
@@ -1,9 +1,19 @@
 import styled from 'styled-components'
+import { Text } from '../../components'
 
 export const RatingImg = styled.img`
   max-width: 100px;
   height: auto;
-  margin: auto;
+  margin: 1rem auto;
+`
+
+export const ConfirmText = styled(Text)`
+  margin: 0px;
+  line-height: 1.5;
+
+  &:nth-child(2) {
+    margin: 0px 0px 15px;
+  }
 `
 
 export const CheckImg = styled.img`

--- a/src/pages/Confirm/index.jsx
+++ b/src/pages/Confirm/index.jsx
@@ -5,7 +5,7 @@ import handshake from '../../assets/handshake.png'
 import RatingMan from '../../assets/man-rate.png'
 import { InsertClientRate, useConfirmPackage } from '../../hooks'
 import Layout from './Confirm.layout'
-import { RatingImg } from './Confirm.styled'
+import { RatingImg, ConfirmText } from './Confirm.styled'
 import warning from '../../assets/warning.png'
 
 const Confirm = () => {
@@ -87,11 +87,15 @@ const Confirm = () => {
       headerSubTitle="Inserta tus datos para finalizar"
       RatingModal={
         <Modal isOpen={isRatingModalOpen} handleClick={e => submitRating(e)} actionText="Aceptar">
+          <ConfirmText small bold color="primary">
+            La propina esta en tus manos
+          </ConfirmText>
+          <ConfirmText margin="0px 0px 15px" bold color="gray">
+            Si deseas, puedes compartirla.
+          </ConfirmText>
           <Text as="h1" color="primary">
             ¿Qué tal tu experiencia?
           </Text>
-          <Text small>La propina esta en tus manos</Text>
-          <Text>Si deseas, puedes compartirla.</Text>
           <RatingImg src={RatingMan} alt="Delivery man" />
           <Rating setRating={setRating} />
         </Modal>


### PR DESCRIPTION
### Description

I have fixed the styles on confirm modal. I have changed the position of subtitle and title, and change the color of subtitle and the weight of text.

I have fixed a bug, the paragraph that are in the modal <InfoContainer> only was be gray, I have fixed this bug deleting that line and checked and the others modals now have the color that should have 

fixes #151

#### Screenshots

![imagen](https://user-images.githubusercontent.com/66505715/152877067-f510ae86-356c-4491-8915-7b2d0acc4d1d.png)

#### Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist:

- [x] Please change the position of the subtitle and title, put the subtitle on the top and the title under the subtitle
- [x] The subtitle is not so separated 
- [x] The subtitle have a stronger color
- [x] The subtitle is bolder